### PR TITLE
Revert "Update eslint-plugin-jsx-a11y to version 3.0.0 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-config-airbnb": "12.0.0",
     "eslint-plugin-filenames": "1.1.0",
     "eslint-plugin-import": "2.0.1",
-    "eslint-plugin-jsx-a11y": "3.0.0",
+    "eslint-plugin-jsx-a11y": "2.2.3",
     "eslint-plugin-mocha": "4.6.0",
     "eslint-plugin-react": "6.4.1"
   }


### PR DESCRIPTION
Reverts Dwolla/eslint-config-dwolla#50 because the release was unpublished
